### PR TITLE
Prevent warnings

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -5,6 +5,7 @@ if enable_config('debug')
 else
   $defs << '-DNDEBUG'
 end
+have_header('ruby/version.h')
 have_func('rb_exec_recursive', 'ruby.h')
 have_func('rb_exec_recursive_paired', 'ruby.h')
 have_func('rb_proc_lambda_p', 'ruby.h')

--- a/rbtree.c
+++ b/rbtree.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2002-2013 OZAWA Takuma
  */
 #include <ruby.h>
+#ifdef HAVE_RUBY_VERSION_H
+#include <ruby/version.h>
+#endif
 #ifdef HAVE_RUBY_ST_H
 #include <ruby/st.h>
 #else
@@ -1276,6 +1279,13 @@ to_a_i(dnode_t* node, void* ary)
     return EACH_NEXT;
 }
 
+
+#if defined(RUBY_API_VERSION_CODE) && RUBY_API_VERSION_CODE >= 30100
+#  define RBTREE_OBJ_INFECT(obj1, obj2)
+#else
+#  define RBTREE_OBJ_INFECT(obj1, obj2) OBJ_INFECT(obj1, obj2)
+#endif
+
 /*
  *
  */
@@ -1284,7 +1294,7 @@ rbtree_to_a(VALUE self)
 {
     VALUE ary = rb_ary_new2(dict_count(DICT(self)));
     rbtree_for_each(self, to_a_i, (void*)ary);
-    OBJ_INFECT(ary, self);
+    RBTREE_OBJ_INFECT(ary, self);
     return ary;
 }
 
@@ -1310,7 +1320,7 @@ rbtree_to_hash(VALUE self)
     RHASH_SET_IFNONE(hash, IFNONE(self));
     if (FL_TEST(self, RBTREE_PROC_DEFAULT))
         FL_SET(hash, HASH_PROC_DEFAULT);
-    OBJ_INFECT(hash, self);
+    RBTREE_OBJ_INFECT(hash, self);
     return hash;
 }
 
@@ -1345,13 +1355,13 @@ inspect_i(dnode_t* node, void* result_)
 
     str = rb_inspect(GET_KEY(node));
     rb_str_append(result, str);
-    OBJ_INFECT(result, str);
+    RBTREE_OBJ_INFECT(result, str);
 
     rb_str_cat2(result, "=>");
 
     str = rb_inspect(GET_VAL(node));
     rb_str_append(result, str);
-    OBJ_INFECT(result, str);
+    RBTREE_OBJ_INFECT(result, str);
 
     return EACH_NEXT;
 }
@@ -1370,15 +1380,15 @@ inspect_rbtree(VALUE self, VALUE result)
     str = rb_inspect(IFNONE(self));
     rb_str_cat2(result, ", default=");
     rb_str_append(result, str);
-    OBJ_INFECT(result, str);
+    RBTREE_OBJ_INFECT(result, str);
 
     str = rb_inspect(CMP_PROC(self));
     rb_str_cat2(result, ", cmp_proc=");
     rb_str_append(result, str);
-    OBJ_INFECT(result, str);
+    RBTREE_OBJ_INFECT(result, str);
 
     rb_str_cat2(result, ">");
-    OBJ_INFECT(result, self);
+    RBTREE_OBJ_INFECT(result, self);
     return result;
 }
 

--- a/rbtree.c
+++ b/rbtree.c
@@ -773,7 +773,11 @@ copy_dict(VALUE src, VALUE dest, dict_comp_t cmp_func, VALUE cmp_proc)
     }
     rbtree_free(RBTREE(temp));
     RBTREE(temp) = NULL;
+#if defined(RUBY_API_VERSION_CODE) && RUBY_API_VERSION_CODE >= 30100
+    /* do nothing */
+#else
     rb_gc_force_recycle(temp);
+#endif
 
     DICT(dest)->dict_context = RBTREE(dest);
     CMP_PROC(dest) = cmp_proc;

--- a/rbtree.c
+++ b/rbtree.c
@@ -141,15 +141,17 @@ rbtree_cmp(const void* key1, const void* key2, void* context)
 }
 
 static VALUE
-rbtree_user_cmp_ensure(rbtree_t* rbtree)
+rbtree_user_cmp_ensure(VALUE arg)
 {
+    rbtree_t* rbtree = (rbtree_t*)arg;
     rbtree->iter_lev--;
     return Qnil;
 }
 
 static VALUE
-rbtree_user_cmp_body(VALUE* args)
+rbtree_user_cmp_body(VALUE arg)
 {
+    VALUE *args = (VALUE*)arg;
     rbtree_t* rbtree = (rbtree_t*)args[2];
     rbtree->iter_lev++;
     return rb_funcall2(rbtree->cmp_proc, id_call, 2, args);
@@ -323,8 +325,9 @@ typedef struct {
 } rbtree_insert_arg_t;
 
 static VALUE
-insert_node_body(rbtree_insert_arg_t* arg)
+insert_node_body(VALUE arg_)
 {
+    rbtree_insert_arg_t* arg = (rbtree_insert_arg_t*)arg_;
     dict_t* dict = arg->dict;
     dnode_t* node = arg->node;
 
@@ -341,8 +344,9 @@ insert_node_body(rbtree_insert_arg_t* arg)
 }
 
 static VALUE
-insert_node_ensure(rbtree_insert_arg_t* arg)
+insert_node_ensure(VALUE arg_)
 {
+    rbtree_insert_arg_t* arg = (rbtree_insert_arg_t*)arg_;
     dict_t* dict = arg->dict;
     dnode_t* node = arg->node;
 
@@ -594,8 +598,9 @@ rbtree_each_ensure(VALUE self)
 }
 
 static VALUE
-rbtree_each_body(rbtree_each_arg_t* arg)
+rbtree_each_body(VALUE arg_)
 {
+    rbtree_each_arg_t* arg = (rbtree_each_arg_t*)arg_;
     VALUE self = arg->self;
     dict_t* dict = DICT(self);
     dnode_t* node;
@@ -892,8 +897,9 @@ typedef struct {
 } rbtree_remove_if_arg_t;
 
 static VALUE
-rbtree_remove_if_ensure(rbtree_remove_if_arg_t* arg)
+rbtree_remove_if_ensure(VALUE arg_)
 {
+    rbtree_remove_if_arg_t* arg = (rbtree_remove_if_arg_t*)arg_;
     dict_t* dict = DICT(arg->self);
     dnode_list_t* list = arg->list;
 
@@ -910,8 +916,9 @@ rbtree_remove_if_ensure(rbtree_remove_if_arg_t* arg)
 }
 
 static VALUE
-rbtree_remove_if_body(rbtree_remove_if_arg_t* arg)
+rbtree_remove_if_body(VALUE arg_)
 {
+    rbtree_remove_if_arg_t* arg = (rbtree_remove_if_arg_t*)arg_;
     VALUE self = arg->self;
     dict_t* dict = DICT(self);
     dnode_t* node;
@@ -1462,8 +1469,9 @@ typedef struct {
 } rbtree_bound_arg_t;
 
 static VALUE
-rbtree_bound_body(rbtree_bound_arg_t* arg)
+rbtree_bound_body(VALUE arg_)
 {
+    rbtree_bound_arg_t* arg = (rbtree_bound_arg_t*)arg_;
     VALUE self = arg->self;
     dict_t* dict = DICT(self);
     dnode_t* lower_node = arg->lower_node;
@@ -1714,16 +1722,18 @@ typedef struct {
 } pp_pair_arg_t;
 
 static VALUE
-pp_value(VALUE nil, pp_pair_arg_t* pair_arg)
+pp_value(RB_BLOCK_CALL_FUNC_ARGLIST(nil, arg))
 {
+    pp_pair_arg_t* pair_arg = (pp_pair_arg_t*)arg;
     VALUE pp = pair_arg->pp;
     rb_funcall(pp, id_breakable, 1, rb_str_new(NULL, 0));
     return rb_funcall(pp, id_pp, 1, GET_VAL(pair_arg->node));
 }
 
 static VALUE
-pp_pair(VALUE nil, pp_pair_arg_t* pair_arg)
+pp_pair(RB_BLOCK_CALL_FUNC_ARGLIST(nil, arg))
 {
+    pp_pair_arg_t* pair_arg = (pp_pair_arg_t*)arg;
     VALUE pp = pair_arg->pp;
     VALUE group_args[4];
     group_args[0] = pp;
@@ -1772,8 +1782,9 @@ typedef struct {
 } pp_rbtree_arg_t;
 
 static VALUE
-pp_each_pair(VALUE nil, pp_rbtree_arg_t* rbtree_arg)
+pp_each_pair(RB_BLOCK_CALL_FUNC_ARGLIST(nil, arg))
 {
+    pp_rbtree_arg_t* rbtree_arg = (pp_rbtree_arg_t*)arg;
     pp_each_pair_arg_t each_pair_arg;
     each_pair_arg.pp = rbtree_arg->pp;
     each_pair_arg.first = 1;
@@ -1781,8 +1792,9 @@ pp_each_pair(VALUE nil, pp_rbtree_arg_t* rbtree_arg)
 }
 
 static VALUE
-pp_rbtree(VALUE nil, pp_rbtree_arg_t* rbtree_arg)
+pp_rbtree(RB_BLOCK_CALL_FUNC_ARGLIST(nil, arg))
 {
+    pp_rbtree_arg_t* rbtree_arg = (pp_rbtree_arg_t*)arg;
     VALUE pp = rbtree_arg->pp;
     VALUE rbtree = rbtree_arg->rbtree;
 

--- a/rbtree.c
+++ b/rbtree.c
@@ -1943,7 +1943,7 @@ rbtree_s_load(VALUE klass, VALUE str)
  * A sorted associative collection that cannot contain duplicate
  * keys. RBTree is a subclass of MultiRBTree.
  */
-void Init_rbtree()
+void Init_rbtree(void)
 {
     MultiRBTree = rb_define_class("MultiRBTree",
 #ifdef HAVE_RB_CDATA

--- a/rbtree.c
+++ b/rbtree.c
@@ -134,7 +134,7 @@ static int
 rbtree_cmp(const void* key1, const void* key2, void* context)
 {
     VALUE result;
-    if (TYPE(key1) == T_STRING && TYPE(key2) == T_STRING)
+    if (TYPE((VALUE)key1) == T_STRING && TYPE((VALUE)key2) == T_STRING)
         return rb_str_cmp((VALUE)key1, (VALUE)key2);
     result = rb_funcall2((VALUE)key1, id_cmp, 1, (VALUE*)&key2);
     return rb_cmpint(result, (VALUE)key1, (VALUE)key2);


### PR DESCRIPTION
This changesets try to suppress compiler warnings. Some of them are already treated as errors by default by clang 15 . #2